### PR TITLE
Fix quoting for table names

### DIFF
--- a/discoverx/explorer.py
+++ b/discoverx/explorer.py
@@ -255,9 +255,11 @@ class DataExplorerActions:
     @staticmethod
     def _build_sql(sql_template: str, table_info: TableInfo) -> str:
         if table_info.catalog and table_info.catalog != "None":
-            full_table_name = f"{table_info.catalog}.{table_info.schema}.{table_info.table}"
+            full_table_name = (
+                f"`{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`"
+            )
         else:
-            full_table_name = f"{table_info.schema}.{table_info.table}"
+            full_table_name = f"`{table_info.schema}`.`{table_info.table}`"
 
         stack_string_columns = DataExplorerActions._get_stack_string_columns_expression(table_info)
         stack_all_columns_as_string = DataExplorerActions._get_stack_all_columns_expression(table_info)

--- a/discoverx/msql.py
+++ b/discoverx/msql.py
@@ -146,9 +146,11 @@ class Msql:
     def _replace_from_statement(self, msql: str, table_info: TableInfo):
         """Replaces the FROM statement in the M-SQL expression with the specified table name"""
         if table_info.catalog and table_info.catalog != "None":
-            replace_with = f"FROM {table_info.catalog}.{table_info.schema}.{table_info.table}"
+            replace_with = (
+                f"FROM `{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`"
+            )
         else:
-            replace_with = f"FROM {table_info.schema}.{table_info.table}"
+            replace_with = f"FROM `{table_info.schema}`.`{table_info.table}`"
 
         return re.sub(self.from_statement_expr, replace_with, msql)
 

--- a/tests/unit/explorer_test.py
+++ b/tests/unit/explorer_test.py
@@ -25,7 +25,7 @@ def test_validate_from_components():
 
 def test_build_sql(sample_table_info):
     sql_template = "SELECT * FROM {full_table_name}"
-    expected_sql = "SELECT * FROM catalog1.schema1.table1"
+    expected_sql = "SELECT * FROM `catalog1`.`schema1`.`table1`"
     assert DataExplorerActions._build_sql(sql_template, sample_table_info) == expected_sql
 
 


### PR DESCRIPTION
## Summary
- quote table names in generated SQL to support hyphenated identifiers
- update unit test expectation

## Testing
- `pytest -q tests/unit/explorer_test.py` *(fails: ModuleNotFoundError: No module named 'mlflow')*

------
https://chatgpt.com/codex/tasks/task_b_686fe8fa3578833191447199a8aa1eb0